### PR TITLE
Gemfileにnokogiriを追加し 1.12.5 以上を使うよう指定を追加した

### DIFF
--- a/toy_app/Gemfile
+++ b/toy_app/Gemfile
@@ -10,6 +10,7 @@ gem 'webpacker', '~> 4.0'
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'nokogiri', '>= 1.12.5'
 
 group :development, :test do
   gem 'sqlite3', '~> 1.4'

--- a/toy_app/Gemfile.lock
+++ b/toy_app/Gemfile.lock
@@ -204,6 +204,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   jbuilder (~> 2.7)
   listen (~> 3.2)
+  nokogiri (>= 1.12.5)
   pg (~> 1.1)
   puma (~> 4.1)
   rails (~> 6.0.4, >= 6.0.4.1)


### PR DESCRIPTION
- 1.12.5 未満は脆弱性があるため
- #4 と同様の対応