### PR TITLE
bootsnap を 1.9.3 に更新する

### DIFF
--- a/hello_app/Gemfile.lock
+++ b/hello_app/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     bindex (0.8.1)
-    bootsnap (1.9.1)
+    bootsnap (1.9.3)
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)

--- a/sample_app/Gemfile.lock
+++ b/sample_app/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     ansi (1.5.0)
     ast (2.4.2)
     bindex (0.8.1)
-    bootsnap (1.9.1)
+    bootsnap (1.9.3)
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)

--- a/toy_app/Gemfile.lock
+++ b/toy_app/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     bindex (0.8.1)
-    bootsnap (1.9.1)
+    bootsnap (1.9.3)
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)


### PR DESCRIPTION
## WHY
- Ruby 3.0.3 では bootsnap を 1.9.1 だと rails server が立ち上がらないため

## WHAT
- Ruby 3.0.3 でも動く bootsnap 1.9.3 に更新する

---

Bumps [bootsnap](https://github.com/Shopify/bootsnap) from 1.9.1 to 1.9.3.
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/Shopify/bootsnap/blob/master/CHANGELOG.md">bootsnap's changelog</a>.</em></p>
<blockquote>
<h1>1.9.3</h1>
<ul>
<li>Only disable the compile cache for source files impacted by <a href="https://bugs.ruby-lang.org/issues/18250">Ruby 3.0.3 [Bug 18250]</a>.
This should keep the performance loss to a minimum.</li>
</ul>
<h1>1.9.2</h1>
<ul>
<li>Disable compile cache if <a href="https://bugs.ruby-lang.org/issues/18250">Ruby 3.0.3's ISeq cache bug</a> is detected.
AKA <code>iseq.rb:13 to_binary: wrong argument type false (expected Symbol)</code></li>
<li>Fix <code>Kernel.load</code> behavior: before <code>load 'a'</code> would load <code>a.rb</code> (and other tried extensions) and wouldn't load <code>a</code> unless <code>development_mode: true</code>, now only <code>a</code> would be loaded and files with extensions wouldn't be.</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/Shopify/bootsnap/commit/a0aa3d2b0cbdcef9d8db9ae787c3628ac250780f"><code>a0aa3d2</code></a> Release 1.9.3</li>
<li><a href="https://github.com/Shopify/bootsnap/commit/6d609ae30b84fb5c6b037d42d6bbe633741fc29f"><code>6d609ae</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/Shopify/bootsnap/issues/380">#380</a> from Shopify/finely-grained-3.0.3-fix</li>
<li><a href="https://github.com/Shopify/bootsnap/commit/ee5982e58922d942abed483fd9b193669d23b002"><code>ee5982e</code></a> Only disable the compile cache for source files impacted by Ruby 3.0.3 [Bug #...</li>
<li><a href="https://github.com/Shopify/bootsnap/commit/d653813e3531a174fe63b26ea38bc8fbd826632f"><code>d653813</code></a> Release 1.9.2</li>
<li><a href="https://github.com/Shopify/bootsnap/commit/1aea48e469615a1dcb92a71099328c34d1c71e10"><code>1aea48e</code></a> Automatically detect Ruby 3.1.0-dev's anonymous params bug</li>
<li><a href="https://github.com/Shopify/bootsnap/commit/b718e075d6c6ac2a2a759860236676c24ae54e41"><code>b718e07</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/Shopify/bootsnap/issues/379">#379</a> from Shopify/improve-ci</li>
<li><a href="https://github.com/Shopify/bootsnap/commit/acefed8db9569b211d664f4165e277e1b26300aa"><code>acefed8</code></a> Run CI against ruby debug builds and run it nightly</li>
<li><a href="https://github.com/Shopify/bootsnap/commit/e1882c5993c3dc7f5fefd06f82287f302c156b28"><code>e1882c5</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/Shopify/bootsnap/issues/373">#373</a> from ojab/optimize_upper_dir_relative_paths</li>
<li><a href="https://github.com/Shopify/bootsnap/commit/2715ef69a0842dd8295ed4d90509eb6ebbafd456"><code>2715ef6</code></a> Optimize relative <code>../</code> paths resolution</li>
<li><a href="https://github.com/Shopify/bootsnap/commit/89b1e97655891970ef15fcc482734e8f7cf663f7"><code>89b1e97</code></a> Optimize LoadedFeatureIndex#register</li>
<li>Additional commits viewable in <a href="https://github.com/Shopify/bootsnap/compare/v1.9.1...v1.9.3">compare view</a></li>
</ul>
</details>
<br />


